### PR TITLE
Fix heap length tagging on 32-bit big-endian targets

### DIFF
--- a/src/repr/heap_buffer.rs
+++ b/src/repr/heap_buffer.rs
@@ -428,7 +428,7 @@ mod internal {
         const ON_THE_HEAP: usize = {
             let mut bytes = [255; USIZE_SIZE];
             bytes[USIZE_SIZE - 1] = LastByte::HeapMarker as u8;
-            usize::from_le_bytes(bytes)
+            usize::from_ne_bytes(bytes)
         };
 
         pub(super) const fn new(size: usize) -> Result<Self, ReserveError> {
@@ -495,4 +495,17 @@ mod internal {
     // - https://github.com/rust-lang/libs-team/issues/510
     #[cold]
     pub(super) fn cold_path() {}
+
+    #[cfg(all(test, target_pointer_width = "32"))]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn heap_stored_length_preserves_repr_tag() {
+            let len = TextLen::new(MAX_LEN + 1).unwrap();
+
+            assert!(len.is_heap());
+            assert_eq!(len.0.to_ne_bytes()[USIZE_SIZE - 1], LastByte::HeapMarker as u8);
+        }
+    }
 }


### PR DESCRIPTION
The 32-bit `ON_THE_HEAP` sentinel describes the native in-memory bytes of `TextLen`, but it was constructed with `usize::from_le_bytes`. This works incidentally on little-endian targets; on a big-endian target such as PowerPC, it moves `HeapMarker` from the final representation byte to the first byte. Large heap-stored lengths can therefore violate `Repr`'s tag invariant and be interpreted as the wrong representation.

This PR instead constructs the sentinel with `usize::from_ne_bytes` so its final native byte remains `HeapMarker` on either endianness.