### PR TITLE
Outline reserve slow paths

### DIFF
--- a/src/repr.rs
+++ b/src/repr.rs
@@ -189,10 +189,12 @@ impl Repr {
         unsafe { slice::from_raw_parts(ptr, len) }
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn reserve(&mut self, additional: usize) -> Result<(), ReserveError> {
         let len = self.len();
-        let needed_capacity = len.checked_add(additional).ok_or(ReserveError)?;
+        let Some(needed_capacity) = len.checked_add(additional) else {
+            return reserve_overflow();
+        };
 
         if self.is_heap_buffer() {
             // SAFETY: We just checked that `self` is HeapBuffer
@@ -204,45 +206,19 @@ impl Repr {
                     return Ok(());
                 }
 
-                let amortized_capacity = heap_buffer::amortized_growth(len, additional);
-                // SAFETY:
-                // - `heap` is unique (verified by `is_unique()`).
-                // - `amortized_capacity` is greater than `len`.
-                unsafe { heap.realloc(amortized_capacity)? };
+                // SAFETY: We just verified that `heap` is unique, and `len` was read from `self`.
+                unsafe { reserve_unique_heap(heap, len, additional) }
             } else {
-                // The heap is shared. We must read the data while our reference is still live
-                // (ref count unchanged), then create a new independent buffer.
-                let str = heap.as_str();
-                let new_heap = HeapBuffer::with_additional(str, additional)?;
-                // Release our reference only after the copy is complete. If the allocation above
-                // fails, ref count remains untouched (no leak).
-                // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
-                unsafe { heap.release() };
-                *self = Repr::from_heap(new_heap);
+                // SAFETY: We identified `self` as a heap buffer above.
+                unsafe { reserve_shared_heap(self, additional) }
             }
-            Ok(())
         } else if self.is_static_buffer() {
-            // We can't modify it, need to convert to other buffer.
-
-            if needed_capacity <= MAX_INLINE_SIZE {
-                // SAFETY: `len <= needed_capacity <= MAX_INLINE_SIZE`
-                let inline = unsafe { InlineBuffer::new(self.as_str()) };
-                *self = Repr::from_inline(inline);
-            } else {
-                let heap = HeapBuffer::with_additional(self.as_str(), additional)?;
-                *self = Repr::from_heap(heap);
-            }
+            reserve_static(self, additional, needed_capacity)
+        } else if needed_capacity <= MAX_INLINE_SIZE {
+            // An inline buffer already has enough capacity.
             Ok(())
         } else {
-            // self is InlineBuffer
-
-            if needed_capacity > MAX_INLINE_SIZE {
-                let heap = HeapBuffer::with_additional(self.as_str(), additional)?;
-                *self = Repr::from_heap(heap);
-            } else {
-                // We have enough capacity, no need to reserve.
-            }
-            Ok(())
+            reserve_inline(self, additional)
         }
     }
 
@@ -725,4 +701,69 @@ impl Repr {
         // SAFETY: A `Repr` is transmuted from `StaticBuffer`
         unsafe { &mut *(self as *mut _ as *mut StaticBuffer) }
     }
+}
+
+#[cold]
+#[inline(never)]
+fn reserve_overflow() -> Result<(), ReserveError> {
+    Err(ReserveError)
+}
+
+#[cold]
+#[inline(never)]
+/// # Safety
+///
+/// `heap` must be unique, and `len` must equal its current length.
+unsafe fn reserve_unique_heap(
+    heap: &mut HeapBuffer,
+    len: usize,
+    additional: usize,
+) -> Result<(), ReserveError> {
+    let amortized_capacity = heap_buffer::amortized_growth(len, additional);
+    // SAFETY:
+    // - The caller verified that `heap` is unique.
+    // - `amortized_capacity` is greater than `len`.
+    unsafe { heap.realloc(amortized_capacity) }
+}
+
+#[cold]
+#[inline(never)]
+/// # Safety
+///
+/// `repr` must contain a live heap buffer.
+unsafe fn reserve_shared_heap(repr: &mut Repr, additional: usize) -> Result<(), ReserveError> {
+    // SAFETY: Guaranteed by the caller.
+    let heap = unsafe { repr.as_heap_buffer_mut() };
+    // Read the data while our counted reference is still live, then create an independent buffer.
+    let new_heap = HeapBuffer::with_additional(heap.as_str(), additional)?;
+    // Release our reference only after the copy is complete. If allocation fails, the reference
+    // count remains untouched. The caller immediately overwrites the old `Repr` and does not use
+    // `heap` again.
+    // SAFETY: `repr` is overwritten immediately below and `heap` is not accessed again.
+    unsafe { heap.release() };
+    *repr = Repr::from_heap(new_heap);
+    Ok(())
+}
+
+#[cold]
+#[inline(never)]
+fn reserve_static(
+    repr: &mut Repr,
+    additional: usize,
+    needed_capacity: usize,
+) -> Result<(), ReserveError> {
+    *repr = if needed_capacity <= MAX_INLINE_SIZE {
+        // SAFETY: `repr.len() <= needed_capacity <= MAX_INLINE_SIZE`.
+        Repr::from_inline(unsafe { InlineBuffer::new(repr.as_str()) })
+    } else {
+        Repr::from_heap(HeapBuffer::with_additional(repr.as_str(), additional)?)
+    };
+    Ok(())
+}
+
+#[cold]
+#[inline(never)]
+fn reserve_inline(repr: &mut Repr, additional: usize) -> Result<(), ReserveError> {
+    *repr = Repr::from_heap(HeapBuffer::with_additional(repr.as_str(), additional)?);
+    Ok(())
 }

--- a/src/repr/heap_buffer.rs
+++ b/src/repr/heap_buffer.rs
@@ -90,6 +90,8 @@ impl HeapBuffer {
         Ok(buffer)
     }
 
+    #[cold]
+    #[inline(never)]
     pub(super) fn with_additional(text: &str, additional: usize) -> Result<Self, ReserveError> {
         let text_len = text.len();
 
@@ -283,6 +285,7 @@ impl HeapBuffer {
         }
     }
 
+    #[inline(always)]
     pub(super) fn is_unique(&self) -> bool {
         self.header().count.load(Acquire) == 1
     }


### PR DESCRIPTION
`reserve` currently carries allocation and copy-on-write logic even when a string already has enough capacity. This moves those uncommon cases into separate functions, making common append and reserve operations faster without changing behavior.

Local Apple arm64 benchmarks showed improvements of 7–29% across the measured append paths, with about a 0.2% increase in code size. The [benchmark suite](https://github.com/astral-sh/lean_string/pull/15) is maintained separately and is not included in this PR.
