### PR TITLE
Add immutable LeanStr

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/lean_string.svg)](https://crates.io/crates/lean_string)
 [![Documentation](https://docs.rs/lean_string/badge.svg)](https://docs.rs/lean_string)
 
-Compact, clone-on-write string.
+Compact owned strings with mutable and immutable variants.
 
 ## Properties
 
@@ -26,6 +26,11 @@ Compact, clone-on-write string.
 - High API compatibility for `String`.
 - Supports `no_std` environment.
 
+`LeanStr` has the same two-word inline, static, and reference-counted representations, but is
+immutable. Its heap allocation is exact and stores only the reference count before the string
+bytes; it does not retain an unused capacity. Use `LeanString::freeze` after building a string, or
+construct a `LeanStr` directly when the final contents are already available.
+
 ## Example
 
 ```rust
@@ -44,6 +49,11 @@ let mut cloned = large.clone();
 cloned.push('!');
 assert_eq!(cloned, "This is a not long but can't store inlined!");
 assert_eq!(large  + "!", cloned);
+
+// Immutable strings have exactly-sized heap storage and still clone in O(1).
+let frozen = LeanString::from("This string was assembled mutably").freeze();
+let shared = frozen.clone();
+assert_eq!(frozen, shared);
 ```
 
 ## Comparison
@@ -55,6 +65,7 @@ assert_eq!(large  + "!", cloned);
 | [`CompactString`](https://docs.rs/compact_str/latest/compact_str/struct.CompactString.html) | 24 bytes | 24 bytes | Yes            | Nich optimized for `Option<_>`                 |
 | [`EcoString`](https://docs.rs/ecow/latest/ecow/string/struct.EcoString.html)                | 16 bytes | 15 bytes | No             | Clone-on-Write, Nich optimized for `Option<_>` |
 | `LeanString` (This crate)                                                                   | 16 bytes | 16 bytes | Yes            | Clone-on-Write, Nich optimized for `Option<_>` |
+| `LeanStr` (This crate)                                                                      | 16 bytes | 16 bytes | Yes            | Immutable, exact heap allocation                |
 
 <details>
 <summary>Above table is for 64-bit architecture. Click here for 32-bit architecture.</summary>
@@ -66,6 +77,7 @@ assert_eq!(large  + "!", cloned);
 | `CompactString`           | 12 bytes | 12 bytes | Yes            | Nich optimized for `Option<_>`                 |
 | `EcoString`               | 8 bytes  | 7 bytes  | No             | Clone-on-Write, Nich optimized for `Option<_>` |
 | `LeanString` (This crate) | 8 bytes  | 8 bytes  | Yes            | Clone-on-Write, Nich optimized for `Option<_>` |
+| `LeanStr` (This crate)    | 8 bytes  | 8 bytes  | Yes            | Immutable, exact heap allocation                |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ Compact owned strings with mutable and immutable variants.
 - High API compatibility for `String`.
 - Supports `no_std` environment.
 
-`LeanStr` has the same two-word inline, static, and reference-counted representations, but is
-immutable. Its heap allocation is exact and stores only the reference count before the string
-bytes; it does not retain an unused capacity. Use `LeanString::freeze` after building a string, or
-construct a `LeanStr` directly when the final contents are already available.
+`LeanString` and `LeanStr` share the same two-word inline and static representations, but use
+different reference-counted heap layouts. Like `String` versus `str`, capacity belongs only to the
+mutable type: every `LeanString` heap allocation stores a capacity and is growable, while every
+`LeanStr` heap allocation is exact and stores only the reference count before the string bytes.
+Converting a unique heap allocation between the types uses `realloc`; converting shared heap
+storage allocates and copies. Use `LeanString::freeze` after building a string, or construct a
+`LeanStr` directly when the final contents are already available.
 
 ## Example
 

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,4 +1,4 @@
-use crate::LeanString;
+use crate::{LeanStr, LeanString};
 use core::{fmt, str};
 use serde_core::{
     de::{Deserialize, Deserializer, Error, Unexpected, Visitor},
@@ -46,5 +46,49 @@ impl<'de> Deserialize<'de> for LeanString {
         }
 
         deserializer.deserialize_string(LeanStringVisitor)
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl Serialize for LeanStr {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de> Deserialize<'de> for LeanStr {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct LeanStrVisitor;
+
+        impl<'de> Visitor<'de> for LeanStrVisitor {
+            type Value = LeanStr;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(LeanStr::from(value))
+            }
+
+            fn visit_borrowed_str<E: Error>(self, value: &'de str) -> Result<Self::Value, E> {
+                Ok(LeanStr::from(value))
+            }
+
+            fn visit_bytes<E: Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+                str::from_utf8(value)
+                    .map(LeanStr::from)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))
+            }
+
+            fn visit_borrowed_bytes<E: Error>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+                self.visit_bytes(value)
+            }
+        }
+
+        deserializer.deserialize_string(LeanStrVisitor)
     }
 }

--- a/src/lean_str.rs
+++ b/src/lean_str.rs
@@ -9,8 +9,12 @@ use crate::{LeanString, Repr, ReserveError, UnwrapWithMsg};
 
 /// Compact, immutable, UTF-8 encoded owned string type.
 ///
-/// Short strings are stored inline. Long strings use an exactly-sized, reference-counted heap
-/// allocation, making clones cheap without retaining a capacity that can never be used.
+/// Values constructed directly store short strings inline. Long strings use an exactly-sized,
+/// reference-counted heap allocation without a capacity field, making clones cheap without
+/// retaining capacity that can never be used. Freezing a heap-allocated [`LeanString`] preserves
+/// the heap storage kind even when its current contents fit inline. Use
+/// [`LeanStr::into_lean_string`] to convert heap storage to the growable layout used by
+/// [`LeanString`].
 #[repr(transparent)]
 pub struct LeanStr(Repr);
 
@@ -73,13 +77,37 @@ impl LeanStr {
         self.0.is_heap_buffer()
     }
 
-    /// Converts this value into a mutable `LeanString` without copying.
+    /// Converts this value into a mutable [`LeanString`].
+    ///
+    /// Unique exact heap storage is converted to growable storage with `realloc`. Shared heap
+    /// storage is copied into a new growable allocation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if reallocating or copying heap storage fails. To handle allocation failure, use
+    /// [`LeanStr::try_into_lean_string`].
     #[inline]
-    pub fn into_lean_string(mut self) -> LeanString {
-        LeanString::from_repr(mem::replace(&mut self.0, Repr::new()))
+    pub fn into_lean_string(self) -> LeanString {
+        self.try_into_lean_string().unwrap_with_msg()
     }
 
-    pub(crate) const fn from_repr(repr: Repr) -> Self {
+    /// Tries to convert this value into a mutable [`LeanString`].
+    ///
+    /// Inline and static storage are transferred without reallocating. Unique exact heap storage
+    /// is converted with `realloc`, while shared heap storage is copied.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ReserveError`] if converting heap storage fails. Because this method consumes
+    /// `self`, the original [`LeanStr`] is dropped on failure.
+    #[inline]
+    pub fn try_into_lean_string(mut self) -> Result<LeanString, ReserveError> {
+        self.0.make_growable()?;
+        Ok(LeanString::from_repr(mem::replace(&mut self.0, Repr::new())))
+    }
+
+    pub(crate) fn from_repr(repr: Repr) -> Self {
+        debug_assert!(!repr.is_growable_heap_buffer());
         Self(repr)
     }
 }

--- a/src/lean_str.rs
+++ b/src/lean_str.rs
@@ -1,0 +1,353 @@
+use core::{borrow::Borrow, cmp, fmt, hash::Hash, hash::Hasher, mem, ops::Deref, str::FromStr};
+
+use alloc::{borrow::Cow, boxed::Box, string::String};
+
+#[cfg(feature = "std")]
+use std::ffi::OsStr;
+
+use crate::{LeanString, Repr, ReserveError, UnwrapWithMsg};
+
+/// Compact, immutable, UTF-8 encoded owned string type.
+///
+/// Short strings are stored inline. Long strings use an exactly-sized, reference-counted heap
+/// allocation, making clones cheap without retaining a capacity that can never be used.
+#[repr(transparent)]
+pub struct LeanStr(Repr);
+
+const _: () = {
+    assert!(size_of::<LeanStr>() == size_of::<[usize; 2]>());
+    assert!(size_of::<Option<LeanStr>>() == size_of::<[usize; 2]>());
+    assert!(align_of::<LeanStr>() == align_of::<usize>());
+    assert!(align_of::<Option<LeanStr>>() == align_of::<usize>());
+};
+
+impl LeanStr {
+    /// Creates an empty `LeanStr`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self(Repr::new())
+    }
+
+    /// Creates a `LeanStr` backed directly by a static string when it does not fit inline.
+    #[inline]
+    pub const fn from_static_str(text: &'static str) -> Self {
+        match Repr::from_static_str(text) {
+            Ok(repr) => Self(repr),
+            Err(_) => panic!("text is too long"),
+        }
+    }
+
+    /// Creates an exactly-sized `LeanStr`.
+    #[inline]
+    pub fn try_from_str(text: &str) -> Result<Self, ReserveError> {
+        Repr::from_exact_str(text).map(Self)
+    }
+
+    /// Returns the string as a string slice.
+    #[inline]
+    pub const fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns the string as a byte slice.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    /// Returns the length in bytes.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the string has a length of zero.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns whether the string uses a reference-counted heap allocation.
+    #[inline]
+    pub const fn is_heap_allocated(&self) -> bool {
+        self.0.is_heap_buffer()
+    }
+
+    /// Converts this value into a mutable `LeanString` without copying.
+    #[inline]
+    pub fn into_lean_string(mut self) -> LeanString {
+        LeanString::from_repr(mem::replace(&mut self.0, Repr::new()))
+    }
+
+    pub(crate) const fn from_repr(repr: Repr) -> Self {
+        Self(repr)
+    }
+}
+
+impl Clone for LeanStr {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.make_shallow_clone())
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        self.0.replace_inner(source.0.make_shallow_clone());
+    }
+}
+
+impl Drop for LeanStr {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.replace_inner(Repr::new());
+    }
+}
+
+// SAFETY: `LeanStr` is `repr(transparent)` over `Repr`, and heap storage is immutable and
+// reference-counted like `Arc`.
+unsafe impl Send for LeanStr {}
+unsafe impl Sync for LeanStr {}
+
+impl Default for LeanStr {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for LeanStr {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Debug for LeanStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Display for LeanStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl AsRef<str> for LeanStr {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsRef<OsStr> for LeanStr {
+    #[inline]
+    fn as_ref(&self) -> &OsStr {
+        OsStr::new(self.as_str())
+    }
+}
+
+impl AsRef<[u8]> for LeanStr {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Borrow<str> for LeanStr {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Eq for LeanStr {}
+
+impl PartialEq for LeanStr {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<str> for LeanStr {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<LeanStr> for str {
+    #[inline]
+    fn eq(&self, other: &LeanStr) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<&str> for LeanStr {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<LeanStr> for &str {
+    #[inline]
+    fn eq(&self, other: &LeanStr) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<String> for LeanStr {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<LeanStr> for String {
+    #[inline]
+    fn eq(&self, other: &LeanStr) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<LeanString> for LeanStr {
+    #[inline]
+    fn eq(&self, other: &LeanString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<LeanStr> for LeanString {
+    #[inline]
+    fn eq(&self, other: &LeanStr) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Ord for LeanStr {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for LeanStr {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Hash for LeanStr {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl From<char> for LeanStr {
+    #[inline]
+    fn from(value: char) -> Self {
+        Self(Repr::from_char(value))
+    }
+}
+
+impl From<&str> for LeanStr {
+    #[inline]
+    #[track_caller]
+    fn from(value: &str) -> Self {
+        Self::try_from_str(value).unwrap_with_msg()
+    }
+}
+
+impl From<String> for LeanStr {
+    #[inline]
+    #[track_caller]
+    fn from(value: String) -> Self {
+        Self::from(value.as_str())
+    }
+}
+
+impl From<&String> for LeanStr {
+    #[inline]
+    #[track_caller]
+    fn from(value: &String) -> Self {
+        Self::from(value.as_str())
+    }
+}
+
+impl From<Cow<'_, str>> for LeanStr {
+    fn from(value: Cow<'_, str>) -> Self {
+        Self::from(value.as_ref())
+    }
+}
+
+impl From<Box<str>> for LeanStr {
+    #[inline]
+    #[track_caller]
+    fn from(value: Box<str>) -> Self {
+        Self::from(value.as_ref())
+    }
+}
+
+impl From<&LeanStr> for LeanStr {
+    #[inline]
+    fn from(value: &LeanStr) -> Self {
+        value.clone()
+    }
+}
+
+impl From<LeanStr> for String {
+    #[inline]
+    fn from(value: LeanStr) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl From<&LeanStr> for String {
+    #[inline]
+    fn from(value: &LeanStr) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl From<LeanString> for LeanStr {
+    #[inline]
+    fn from(value: LeanString) -> Self {
+        value.freeze()
+    }
+}
+
+impl From<LeanStr> for LeanString {
+    #[inline]
+    fn from(value: LeanStr) -> Self {
+        value.into_lean_string()
+    }
+}
+
+impl FromStr for LeanStr {
+    type Err = ReserveError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from_str(s)
+    }
+}
+
+impl FromIterator<char> for LeanStr {
+    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
+        LeanString::from_iter(iter).freeze()
+    }
+}
+
+impl<'a> FromIterator<&'a char> for LeanStr {
+    fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
+        iter.into_iter().copied().collect()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,14 +917,15 @@ impl LeanString {
         Ok(other)
     }
 
-    /// Reduces the length of the [`LeanString`] to zero.
+    /// Reduces the length of the [`LeanString`] to zero without allocating.
     ///
-    /// If the [`LeanString`] is unique, this method will not change the capacity.
-    /// Otherwise, creates a new unique [`LeanString`] without heap allocation.
+    /// If the [`LeanString`] has a unique growable buffer, this method will not change the
+    /// capacity. Exact and shared heap buffers are released, leaving an empty inline
+    /// [`LeanString`].
     ///
     /// # Examples
     ///
-    /// ## unique
+    /// ## unique growable buffer
     ///
     /// ```
     /// # use lean_string::LeanString;
@@ -937,7 +938,7 @@ impl LeanString {
     /// assert_eq!(s.capacity(), 38);
     /// ```
     ///
-    /// ## not unique
+    /// ## shared growable buffer
     ///
     /// ```
     /// # use lean_string::LeanString;
@@ -952,7 +953,7 @@ impl LeanString {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        self.0.clear().unwrap_with_msg();
+        self.0.clear();
     }
 
     /// Returns whether the [`LeanString`] is heap-allocated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ use std::ffi::OsStr;
 mod repr;
 use repr::Repr;
 
+mod lean_str;
+pub use lean_str::LeanStr;
+
 mod errors;
 pub use errors::*;
 
@@ -44,6 +47,10 @@ const _: () = {
 };
 
 impl LeanString {
+    pub(crate) const fn from_repr(repr: Repr) -> Self {
+        Self(repr)
+    }
+
     /// Creates a new empty [`LeanString`].
     ///
     /// Same as [`String::new()`], this will not allocate on the heap.
@@ -59,6 +66,13 @@ impl LeanString {
     #[inline]
     pub const fn new() -> Self {
         LeanString(Repr::new())
+    }
+
+    /// Converts this value into an immutable, exactly allocated [`LeanStr`].
+    #[inline]
+    pub fn freeze(mut self) -> LeanStr {
+        self.0.shrink_to(0).unwrap_with_msg();
+        LeanStr::from_repr(core::mem::replace(&mut self.0, Repr::new()))
     }
 
     /// Creates a new [`LeanString`] from a `&'static str`.
@@ -938,14 +952,7 @@ impl LeanString {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        if self.0.is_unique() {
-            // SAFETY:
-            // - `self` is unique.
-            // - 0 bytes is always valid UTF-8, and initialized.
-            unsafe { self.0.set_len(0) }
-        } else {
-            self.0.replace_inner(Repr::new());
-        }
+        self.0.clear().unwrap_with_msg();
     }
 
     /// Returns whether the [`LeanString`] is heap-allocated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ pub use traits::ToLeanString;
 mod features;
 
 /// Compact, clone-on-write, UTF-8 encoded, growable string type.
+///
+/// Heap allocations store a capacity and are always growable. Use [`LeanString::freeze`] to
+/// convert to the capacity-less heap representation used by [`LeanStr`].
 #[repr(transparent)]
 pub struct LeanString(Repr);
 
@@ -47,7 +50,8 @@ const _: () = {
 };
 
 impl LeanString {
-    pub(crate) const fn from_repr(repr: Repr) -> Self {
+    pub(crate) fn from_repr(repr: Repr) -> Self {
+        debug_assert!(!repr.is_exact_heap_buffer());
         Self(repr)
     }
 
@@ -70,11 +74,12 @@ impl LeanString {
 
     /// Converts this value into an immutable, exactly allocated [`LeanStr`].
     ///
-    /// Growable heap storage may require a new exactly sized allocation.
+    /// Unique growable heap storage is converted to exact storage with `realloc`. Shared heap
+    /// storage is copied into a new exact allocation.
     ///
     /// # Panics
     ///
-    /// Panics if allocating the exactly sized buffer fails. To handle allocation failure, use
+    /// Panics if converting heap storage fails. To handle allocation failure, use
     /// [`LeanString::try_freeze()`].
     #[inline]
     pub fn freeze(self) -> LeanStr {
@@ -83,16 +88,16 @@ impl LeanString {
 
     /// Tries to convert this value into an immutable, exactly allocated [`LeanStr`].
     ///
-    /// Inline, static, and already exact storage do not allocate. Growable heap storage may
-    /// require a new exactly sized allocation.
+    /// Inline and static storage are transferred without reallocating. Unique growable heap
+    /// storage is converted with `realloc`, while shared heap storage is copied.
     ///
     /// # Errors
     ///
-    /// Returns a [`ReserveError`] if allocating the exactly sized buffer fails. Because this
-    /// method consumes `self`, the original [`LeanString`] is dropped on failure.
+    /// Returns a [`ReserveError`] if converting heap storage fails. Because this method consumes
+    /// `self`, the original [`LeanString`] is dropped on failure.
     #[inline]
     pub fn try_freeze(mut self) -> Result<LeanStr, ReserveError> {
-        self.0.shrink_to(0)?;
+        self.0.make_exact()?;
         Ok(LeanStr::from_repr(core::mem::replace(&mut self.0, Repr::new())))
     }
 
@@ -322,9 +327,9 @@ impl LeanString {
 
     /// Returns the capacity of the [`LeanString`], in bytes.
     ///
-    /// A [`LeanString`] will inline strings if the length is less than or equal to
-    /// `2 * size_of::<usize>()` bytes. This means that the minimum capacity of a [`LeanString`]
-    /// is `2 * size_of::<usize>()` bytes.
+    /// Inline values have a capacity of `2 * size_of::<usize>()` bytes. Heap values return their
+    /// stored growable capacity. A heap-allocated [`LeanStr`] remains heap-allocated when converted
+    /// to growable storage, so the resulting capacity can be smaller than the inline capacity.
     ///
     /// # Examples
     ///
@@ -941,8 +946,7 @@ impl LeanString {
     /// Reduces the length of the [`LeanString`] to zero without allocating.
     ///
     /// If the [`LeanString`] has a unique growable buffer, this method will not change the
-    /// capacity. Exact and shared heap buffers are released, leaving an empty inline
-    /// [`LeanString`].
+    /// capacity. Shared heap buffers are released, leaving an empty inline [`LeanString`].
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,31 @@ impl LeanString {
     }
 
     /// Converts this value into an immutable, exactly allocated [`LeanStr`].
+    ///
+    /// Growable heap storage may require a new exactly sized allocation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if allocating the exactly sized buffer fails. To handle allocation failure, use
+    /// [`LeanString::try_freeze()`].
     #[inline]
-    pub fn freeze(mut self) -> LeanStr {
-        self.0.shrink_to(0).unwrap_with_msg();
-        LeanStr::from_repr(core::mem::replace(&mut self.0, Repr::new()))
+    pub fn freeze(self) -> LeanStr {
+        self.try_freeze().unwrap_with_msg()
+    }
+
+    /// Tries to convert this value into an immutable, exactly allocated [`LeanStr`].
+    ///
+    /// Inline, static, and already exact storage do not allocate. Growable heap storage may
+    /// require a new exactly sized allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ReserveError`] if allocating the exactly sized buffer fails. Because this
+    /// method consumes `self`, the original [`LeanString`] is dropped on failure.
+    #[inline]
+    pub fn try_freeze(mut self) -> Result<LeanStr, ReserveError> {
+        self.0.shrink_to(0)?;
+        Ok(LeanStr::from_repr(core::mem::replace(&mut self.0, Repr::new())))
     }
 
     /// Creates a new [`LeanString`] from a `&'static str`.

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -585,16 +585,10 @@ impl Repr {
     }
 
     #[inline]
-    pub(crate) fn clear(&mut self) -> Result<(), ReserveError> {
+    pub(crate) fn clear(&mut self) {
         if self.is_exact_heap_buffer() {
-            // A unique exact buffer becomes growable so that its old length remains available as
-            // its capacity. A shared buffer can release this handle without preserving capacity.
-            if self.is_unique() {
-                let next = Repr::from_heap(HeapBuffer::with_capacity(self.len())?);
-                self.replace_inner(next);
-            } else {
-                self.replace_inner(Repr::new());
-            }
+            // Exact buffers do not store a capacity that can be retained after their length changes.
+            self.replace_inner(Repr::new());
         } else if self.is_unique() {
             // SAFETY:
             // - `self` is unique.
@@ -604,7 +598,6 @@ impl Repr {
         } else {
             self.replace_inner(Repr::new());
         }
-        Ok(())
     }
 
     #[inline]

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -112,6 +112,56 @@ impl Repr {
         }
     }
 
+    /// Converts growable heap storage to exact heap storage.
+    ///
+    /// Inline and static storage are left unchanged. A unique heap allocation is converted with
+    /// `realloc`; shared heap storage is copied into a new exact allocation.
+    pub(crate) fn make_exact(&mut self) -> Result<(), ReserveError> {
+        if !self.is_heap_buffer() {
+            return Ok(());
+        }
+
+        // SAFETY: We just checked that `self` is a heap buffer.
+        let heap = unsafe { self.as_heap_buffer_mut() };
+        debug_assert!(!heap.is_exact());
+
+        if heap.is_unique() {
+            // SAFETY: `heap` is growable and uniquely owned.
+            unsafe { heap.realloc_into_exact() }
+        } else {
+            let new_heap = HeapBuffer::new_exact(heap.as_str())?;
+            // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
+            unsafe { heap.release() };
+            *self = Repr::from_heap(new_heap);
+            Ok(())
+        }
+    }
+
+    /// Converts exact heap storage to growable heap storage.
+    ///
+    /// Inline and static storage are left unchanged. A unique heap allocation is converted with
+    /// `realloc`; shared heap storage is copied into a new growable allocation.
+    pub(crate) fn make_growable(&mut self) -> Result<(), ReserveError> {
+        if !self.is_heap_buffer() {
+            return Ok(());
+        }
+
+        // SAFETY: We just checked that `self` is a heap buffer.
+        let heap = unsafe { self.as_heap_buffer_mut() };
+        debug_assert!(heap.is_exact());
+
+        if heap.is_unique() {
+            // SAFETY: `heap` is exact and uniquely owned.
+            unsafe { heap.realloc_into_growable() }
+        } else {
+            let new_heap = HeapBuffer::new(heap.as_str())?;
+            // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
+            unsafe { heap.release() };
+            *self = Repr::from_heap(new_heap);
+            Ok(())
+        }
+    }
+
     #[cfg(target_pointer_width = "64")]
     #[inline]
     pub(crate) const fn len(&self) -> usize {
@@ -207,18 +257,9 @@ impl Repr {
         if self.is_heap_buffer() {
             // SAFETY: We just checked that `self` is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
+            debug_assert!(!heap.is_exact());
 
-            if heap.is_exact() {
-                if additional == 0 {
-                    return Ok(());
-                }
-
-                let str = heap.as_str();
-                let new_heap = HeapBuffer::with_additional(str, additional)?;
-                // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
-                unsafe { heap.release() };
-                *self = Repr::from_heap(new_heap);
-            } else if heap.is_unique() {
+            if heap.is_unique() {
                 if heap.capacity() >= needed_capacity {
                     // No need to reserve more capacity.
                     return Ok(());
@@ -275,10 +316,7 @@ impl Repr {
 
         // SAFETY: We did early return if the buffer is not HeapBuffer.
         let heap = unsafe { self.as_heap_buffer_mut() };
-
-        if heap.is_exact() {
-            return Ok(());
-        }
+        debug_assert!(!heap.is_exact());
 
         let new_capacity = heap.len().max(min_capacity);
         let old_capacity = heap.capacity();
@@ -290,11 +328,6 @@ impl Repr {
             // thus, `heap.len() <= MAX_INLINE_SIZE`
             let inline = unsafe { InlineBuffer::new(heap.as_str()) };
             self.replace_inner(Repr::from_inline(inline));
-        } else if new_capacity == heap.len() {
-            let new_heap = HeapBuffer::new_exact(heap.as_str())?;
-            // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
-            unsafe { heap.release() };
-            *self = Repr::from_heap(new_heap);
         } else if new_capacity >= old_capacity {
             // No need to shrink the buffer.
         } else if heap.is_unique() {
@@ -524,21 +557,9 @@ impl Repr {
         if self.is_heap_buffer() {
             // SAFETY: We just checked that `self` is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
+            debug_assert!(!heap.is_exact());
 
-            if heap.is_exact() {
-                // An exact allocation's original length is also its allocation size, so changing
-                // the length requires a growable allocation that records the old capacity.
-                let capacity = heap.len();
-                let str = unsafe {
-                    let ptr = heap.ptr().as_ptr();
-                    let slice = slice::from_raw_parts(ptr, new_len);
-                    str::from_utf8_unchecked(slice)
-                };
-                let new_repr = Repr::from_heap(HeapBuffer::with_exact_capacity(str, capacity)?);
-                // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
-                unsafe { heap.release() };
-                *self = new_repr;
-            } else if !heap.is_len_on_heap() {
+            if !heap.is_len_on_heap() {
                 // Since len is inlined and we don't modify the buffer by popping a char, it is ok
                 // to just set the new length.
                 // SAFETY: `new_len <= len <= capacity`
@@ -586,13 +607,11 @@ impl Repr {
 
     #[inline]
     pub(crate) fn clear(&mut self) {
-        if self.is_exact_heap_buffer() {
-            // Exact buffers do not store a capacity that can be retained after their length changes.
-            self.replace_inner(Repr::new());
-        } else if self.is_unique() {
+        debug_assert!(!self.is_exact_heap_buffer());
+        if self.is_unique() {
             // SAFETY:
             // - `self` is unique.
-            // - Exact heap buffers returned above.
+            // - A heap buffer is growable.
             // - 0 bytes is always initialized and valid UTF-8.
             unsafe { self.set_len(0) };
         } else {
@@ -657,8 +676,13 @@ impl Repr {
     }
 
     #[inline(always)]
-    const fn is_exact_heap_buffer(&self) -> bool {
+    pub(crate) const fn is_exact_heap_buffer(&self) -> bool {
         self.last_byte() == LastByte::ExactHeapMarker as u8
+    }
+
+    #[inline(always)]
+    pub(crate) const fn is_growable_heap_buffer(&self) -> bool {
+        self.last_byte() == LastByte::HeapMarker as u8
     }
 
     #[inline(always)]
@@ -676,9 +700,10 @@ impl Repr {
         if self.is_heap_buffer() {
             // SAFETY: we just checked self is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
+            debug_assert!(!heap.is_exact());
 
-            if heap.is_exact() || !heap.is_unique() {
-                // Exact and shared buffers both need a new growable allocation.
+            if !heap.is_unique() {
+                // Shared buffers need a new growable allocation.
                 let str = heap.as_str();
                 let new_heap = HeapBuffer::with_exact_capacity(str, str.len())?;
                 // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -56,6 +56,16 @@ impl Repr {
     }
 
     #[inline]
+    pub(crate) fn from_exact_str(text: &str) -> Result<Self, ReserveError> {
+        if text.len() <= MAX_INLINE_SIZE {
+            // SAFETY: `text.len()` is less than or equal to `MAX_INLINE_SIZE`.
+            Ok(Repr::from_inline(unsafe { InlineBuffer::new(text) }))
+        } else {
+            HeapBuffer::new_exact(text).map(Repr::from_heap)
+        }
+    }
+
+    #[inline]
     pub(crate) fn from_char(ch: char) -> Self {
         let inline = unsafe {
             let mut buffer = [0; 4];
@@ -123,7 +133,7 @@ impl Repr {
         };
 
         // This code is compiled to a single branchless instruction, such as `cmov`
-        if last_byte < LastByte::HeapMarker as u8 {
+        if last_byte < LastByte::ExactHeapMarker as u8 {
             len = inline_len
         }
 
@@ -178,7 +188,7 @@ impl Repr {
     pub(crate) const fn as_bytes(&self) -> &[u8] {
         let len = self.len();
 
-        let ptr = if self.last_byte() >= LastByte::HeapMarker as u8 {
+        let ptr = if self.last_byte() >= LastByte::ExactHeapMarker as u8 {
             self.0 as *const u8
         } else {
             self as *const _ as *const u8
@@ -198,7 +208,17 @@ impl Repr {
             // SAFETY: We just checked that `self` is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
 
-            if heap.is_unique() {
+            if heap.is_exact() {
+                if additional == 0 {
+                    return Ok(());
+                }
+
+                let str = heap.as_str();
+                let new_heap = HeapBuffer::with_additional(str, additional)?;
+                // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
+                unsafe { heap.release() };
+                *self = Repr::from_heap(new_heap);
+            } else if heap.is_unique() {
                 if heap.capacity() >= needed_capacity {
                     // No need to reserve more capacity.
                     return Ok(());
@@ -256,6 +276,10 @@ impl Repr {
         // SAFETY: We did early return if the buffer is not HeapBuffer.
         let heap = unsafe { self.as_heap_buffer_mut() };
 
+        if heap.is_exact() {
+            return Ok(());
+        }
+
         let new_capacity = heap.len().max(min_capacity);
         let old_capacity = heap.capacity();
 
@@ -266,6 +290,11 @@ impl Repr {
             // thus, `heap.len() <= MAX_INLINE_SIZE`
             let inline = unsafe { InlineBuffer::new(heap.as_str()) };
             self.replace_inner(Repr::from_inline(inline));
+        } else if new_capacity == heap.len() {
+            let new_heap = HeapBuffer::new_exact(heap.as_str())?;
+            // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
+            unsafe { heap.release() };
+            *self = Repr::from_heap(new_heap);
         } else if new_capacity >= old_capacity {
             // No need to shrink the buffer.
         } else if heap.is_unique() {
@@ -439,6 +468,10 @@ impl Repr {
             "index is not a char boundary or out of bounds (index: {idx})",
         );
 
+        if string.is_empty() {
+            return Ok(());
+        }
+
         let new_len = self.len().checked_add(string.len()).ok_or(ReserveError)?;
 
         // reserve makes self unique and modifiable
@@ -492,7 +525,20 @@ impl Repr {
             // SAFETY: We just checked that `self` is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
 
-            if !heap.is_len_on_heap() {
+            if heap.is_exact() {
+                // An exact allocation's original length is also its allocation size, so changing
+                // the length requires a growable allocation that records the old capacity.
+                let capacity = heap.len();
+                let str = unsafe {
+                    let ptr = heap.ptr().as_ptr();
+                    let slice = slice::from_raw_parts(ptr, new_len);
+                    str::from_utf8_unchecked(slice)
+                };
+                let new_repr = Repr::from_heap(HeapBuffer::with_exact_capacity(str, capacity)?);
+                // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
+                unsafe { heap.release() };
+                *self = new_repr;
+            } else if !heap.is_len_on_heap() {
                 // Since len is inlined and we don't modify the buffer by popping a char, it is ok
                 // to just set the new length.
                 // SAFETY: `new_len <= len <= capacity`
@@ -536,6 +582,29 @@ impl Repr {
         } else {
             true
         }
+    }
+
+    #[inline]
+    pub(crate) fn clear(&mut self) -> Result<(), ReserveError> {
+        if self.is_exact_heap_buffer() {
+            // A unique exact buffer becomes growable so that its old length remains available as
+            // its capacity. A shared buffer can release this handle without preserving capacity.
+            if self.is_unique() {
+                let next = Repr::from_heap(HeapBuffer::with_capacity(self.len())?);
+                self.replace_inner(next);
+            } else {
+                self.replace_inner(Repr::new());
+            }
+        } else if self.is_unique() {
+            // SAFETY:
+            // - `self` is unique.
+            // - Exact heap buffers returned above.
+            // - 0 bytes is always initialized and valid UTF-8.
+            unsafe { self.set_len(0) };
+        } else {
+            self.replace_inner(Repr::new());
+        }
+        Ok(())
     }
 
     #[inline]
@@ -590,7 +659,13 @@ impl Repr {
 
     #[inline(always)]
     pub(crate) const fn is_heap_buffer(&self) -> bool {
-        self.last_byte() == LastByte::HeapMarker as u8
+        let last_byte = self.last_byte();
+        last_byte == LastByte::ExactHeapMarker as u8 || last_byte == LastByte::HeapMarker as u8
+    }
+
+    #[inline(always)]
+    const fn is_exact_heap_buffer(&self) -> bool {
+        self.last_byte() == LastByte::ExactHeapMarker as u8
     }
 
     #[inline(always)]
@@ -609,10 +684,10 @@ impl Repr {
             // SAFETY: we just checked self is HeapBuffer
             let heap = unsafe { self.as_heap_buffer_mut() };
 
-            if !heap.is_unique() {
-                // `heap` is shared, we need to create a new buffer.
+            if heap.is_exact() || !heap.is_unique() {
+                // Exact and shared buffers both need a new growable allocation.
                 let str = heap.as_str();
-                let new_heap = HeapBuffer::new(str)?;
+                let new_heap = HeapBuffer::with_exact_capacity(str, str.len())?;
                 // SAFETY: `self` is overwritten immediately below and `heap` is not accessed again.
                 unsafe { heap.release() };
                 *self = Repr::from_heap(new_heap);
@@ -621,7 +696,12 @@ impl Repr {
             }
         } else if self.is_static_buffer() {
             // StaticBuffer is immutable, need to convert to other buffer.
-            let next = Repr::from_str(self.as_str())?;
+            let next = if self.len() <= MAX_INLINE_SIZE {
+                // SAFETY: The length was checked above.
+                Repr::from_inline(unsafe { InlineBuffer::new(self.as_str()) })
+            } else {
+                Repr::from_heap(HeapBuffer::with_exact_capacity(self.as_str(), self.len())?)
+            };
             self.replace_inner(next);
         }
         Ok(())
@@ -632,11 +712,13 @@ impl Repr {
     /// # Safety
     /// - The buffer is not StaticBuffer
     /// - If the buffer is HeapBuffer, it must be unique.
+    /// - If the buffer is HeapBuffer, it must be growable.
     ///
     /// Only the bytes in `0..self.len()` are initialized. The bytes from `self.len()` to
     /// `self.capacity()` may be uninitialized and must not be used to create references to `u8`.
     unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
         debug_assert!(!self.is_static_buffer());
+        debug_assert!(!self.is_exact_heap_buffer());
 
         if self.is_heap_buffer() {
             let ptr = self.0 as *mut u8;
@@ -653,6 +735,7 @@ impl Repr {
     /// - `new_len` must be less than or equal to `capacity()`
     /// - The elements at `0..new_len` must be initialized and valid UTF-8.
     /// - If the underlying buffer is a `HeapBuffer`, it must be unique.
+    /// - If the underlying buffer is a `HeapBuffer`, it must be growable.
     /// - If the underlying buffer is a `InlineBuffer`, `new_len <= MAX_INLINE_SIZE` must be true.
     #[inline]
     pub(crate) unsafe fn set_len(&mut self, new_len: usize) {
@@ -667,6 +750,7 @@ impl Repr {
             // SAFETY:
             // - We just checked that `self` is HeapBuffer.
             // - From `#Safety`, the buffer is unique.
+            // - From `#Safety`, the buffer is growable.
             unsafe { self.as_heap_buffer_mut().set_len(new_len) };
         } else {
             // SAFETY:

--- a/src/repr/heap_buffer.rs
+++ b/src/repr/heap_buffer.rs
@@ -163,6 +163,7 @@ impl HeapBuffer {
 
     /// # Safety
     /// - The buffer must be unique. (HeapBuffer::is_unique() == true)
+    /// - The buffer must be growable. (`HeapBuffer::is_exact() == false`)
     /// - `new_capacity` must be greater than or equal to the current string length.
     pub(super) unsafe fn realloc(&mut self, new_capacity: usize) -> Result<(), ReserveError> {
         debug_assert!(!self.is_exact());
@@ -318,6 +319,7 @@ impl HeapBuffer {
     /// # Safety
     /// - `len` bytes in the buffer must be valid UTF-8.
     /// - `len` must be less than or equal to the capacity.
+    /// - The buffer must be growable. (`HeapBuffer::is_exact() == false`)
     /// - If `len` is stored on the heap, the buffer must be unique.
     pub(super) unsafe fn set_len(&mut self, len: usize) {
         debug_assert!(!self.is_exact());

--- a/src/repr/heap_buffer.rs
+++ b/src/repr/heap_buffer.rs
@@ -19,19 +19,27 @@ pub(crate) fn amortized_growth(cur_len: usize, additional: usize) -> usize {
 
 #[repr(C)]
 pub(super) struct HeapBuffer {
-    // 64-bit architecture or 32-bit architecture if `is_len_heap_layout` is false:
+    // Exact buffers omit the capacity because it is equal to their length:
+    // | ExactHeader | Data (array of `u8`) |
+    //                 ^ ptr
+    //
+    // Growable buffers retain a capacity:
     // | Header | Data (array of `u8`) |
     //          ^ ptr
-    // 32-bit architecture if `is_len_heap_layout` is true:
-    // | Length | Header | Data (array of `u8`) |
-    //                   ^ ptr
+    //
+    // On 32-bit architectures, buffers whose allocation can exceed the inline length limit
+    // prepend a `usize` containing the length.
     ptr: NonNull<u8>,
     len: TextLen,
 }
 
-struct Header {
+struct ExactHeader {
     count: AtomicUsize,
+}
+
+struct Header {
     capacity: Capacity,
+    count: AtomicUsize,
 }
 
 const _: () = {
@@ -41,16 +49,19 @@ const _: () = {
 
 impl HeapBuffer {
     pub(super) fn new(text: &str) -> Result<Self, ReserveError> {
+        HeapBuffer::with_exact_capacity(text, text.len())
+    }
+
+    pub(super) fn new_exact(text: &str) -> Result<Self, ReserveError> {
         let text_len = text.len();
 
-        let len = TextLen::new(text_len)?;
-        let ptr = HeapBuffer::allocate_ptr(Capacity::new(text_len)?)?;
+        let len = TextLen::new_exact(text_len)?;
+        let ptr = HeapBuffer::allocate_exact_ptr(text_len)?;
 
         if len.is_heap() {
-            // SAFETY: Since we passed `text_len` as the capacity and `len` equals to `text_len`,
-            // `ptr` is allocated with enough space to store the length.
+            // SAFETY: `allocate_exact_ptr` reserved space for the heap-stored length.
             unsafe {
-                let len_ptr = ptr.sub(HeapBuffer::header_offset()).sub(size_of::<usize>());
+                let len_ptr = ptr.sub(HeapBuffer::exact_header_offset()).sub(size_of::<usize>());
                 ptr::write(len_ptr.as_ptr().cast(), text_len);
             }
         }
@@ -66,9 +77,9 @@ impl HeapBuffer {
     }
 
     pub(crate) fn with_capacity(capacity: usize) -> Result<Self, ReserveError> {
-        let len = TextLen::new(0)?;
+        let len = TextLen::new_growable(0)?;
         let cap = Capacity::new(capacity)?;
-        let ptr = HeapBuffer::allocate_ptr(cap)?;
+        let ptr = HeapBuffer::allocate_growable_ptr(cap)?;
         Ok(HeapBuffer { ptr, len })
     }
 
@@ -93,17 +104,17 @@ impl HeapBuffer {
     pub(super) fn with_additional(text: &str, additional: usize) -> Result<Self, ReserveError> {
         let text_len = text.len();
 
-        let len = TextLen::new(text_len)?;
+        let len = TextLen::new_growable(text_len)?;
         let ptr = {
             let new_capacity = Capacity::new(amortized_growth(text_len, additional))?;
-            HeapBuffer::allocate_ptr(new_capacity)?
+            HeapBuffer::allocate_growable_ptr(new_capacity)?
         };
 
         if len.is_heap() {
             // SAFETY: Since the `new_capacity` is greater than or equal to `text_len`, `ptr` is
             // allocated with enough space to store the length.
             unsafe {
-                let len_ptr = ptr.sub(HeapBuffer::header_offset()).sub(size_of::<usize>());
+                let len_ptr = ptr.sub(HeapBuffer::growable_header_offset()).sub(size_of::<usize>());
                 ptr::write(len_ptr.as_ptr().cast(), text_len);
             }
         }
@@ -120,7 +131,11 @@ impl HeapBuffer {
     }
 
     pub(super) fn capacity(&self) -> usize {
-        self.header().capacity.as_usize()
+        if self.is_exact() { self.len() } else { self.header().capacity.as_usize() }
+    }
+
+    pub(super) const fn is_exact(&self) -> bool {
+        self.len.is_exact()
     }
 
     pub(crate) fn ptr(&self) -> NonNull<u8> {
@@ -128,15 +143,15 @@ impl HeapBuffer {
     }
 
     pub(super) const fn len(&self) -> usize {
-        #[cold]
-        const fn len_on_heap(ptr: NonNull<u8>) -> usize {
-            // SAFETY: We just checked that `len` is stored on the heap.
+        if self.len.is_heap() {
+            // SAFETY: The allocation includes a heap-stored length immediately before its header.
             unsafe {
-                let len_ptr = ptr.sub(HeapBuffer::header_offset()).sub(size_of::<usize>());
+                let len_ptr = self.ptr.sub(self.header_offset()).sub(size_of::<usize>());
                 ptr::read(len_ptr.as_ptr().cast())
             }
+        } else {
+            self.len.as_usize()
         }
-        if self.len.is_heap() { len_on_heap(self.ptr) } else { self.len.as_usize() }
     }
 
     pub(super) fn as_str(&self) -> &str {
@@ -150,6 +165,7 @@ impl HeapBuffer {
     /// - The buffer must be unique. (HeapBuffer::is_unique() == true)
     /// - `new_capacity` must be greater than or equal to the current string length.
     pub(super) unsafe fn realloc(&mut self, new_capacity: usize) -> Result<(), ReserveError> {
+        debug_assert!(!self.is_exact());
         debug_assert!(self.is_unique());
         debug_assert!(self.len() <= new_capacity);
 
@@ -229,11 +245,11 @@ impl HeapBuffer {
             ptr::write(
                 allocation.cast(),
                 Header {
-                    count: AtomicUsize::new(1), // is_unique() is true.
                     capacity: new_capacity,
+                    count: AtomicUsize::new(1), // is_unique() is true.
                 },
             );
-            let ptr = allocation.add(HeapBuffer::header_offset());
+            let ptr = allocation.add(HeapBuffer::growable_header_offset());
             self.ptr = NonNull::new_unchecked(ptr);
         }
         Ok(())
@@ -266,7 +282,11 @@ impl HeapBuffer {
     ///   from them may be read or otherwise accessed. The `HeapBuffer` value itself may only be
     ///   immediately overwritten or forgotten.
     unsafe fn dealloc(&mut self) {
-        let layout = match HeapBuffer::layout_from_capacity(self.header().capacity) {
+        let layout = match if self.is_exact() {
+            HeapBuffer::layout_from_len(self.len())
+        } else {
+            HeapBuffer::layout_from_capacity(self.header().capacity)
+        } {
             Ok(layout) => layout,
             Err(_) => {
                 if cfg!(debug_assertions) {
@@ -284,7 +304,7 @@ impl HeapBuffer {
     }
 
     pub(super) fn is_unique(&self) -> bool {
-        self.header().count.load(Acquire) == 1
+        self.reference_count().load(Acquire) == 1
     }
 
     pub(super) fn is_len_on_heap(&self) -> bool {
@@ -292,7 +312,7 @@ impl HeapBuffer {
     }
 
     pub(super) fn reference_count(&self) -> &AtomicUsize {
-        &self.header().count
+        if self.is_exact() { &self.exact_header().count } else { &self.header().count }
     }
 
     /// # Safety
@@ -300,9 +320,10 @@ impl HeapBuffer {
     /// - `len` must be less than or equal to the capacity.
     /// - If `len` is stored on the heap, the buffer must be unique.
     pub(super) unsafe fn set_len(&mut self, len: usize) {
+        debug_assert!(!self.is_exact());
         debug_assert!(len <= self.capacity());
 
-        let new_len = match TextLen::new(len) {
+        let new_len = match TextLen::new_growable(len) {
             Ok(len) => len,
             Err(_) => {
                 if cfg!(debug_assertions) {
@@ -320,7 +341,7 @@ impl HeapBuffer {
         fn write_len_on_heap(ptr: NonNull<u8>, len: usize) {
             // SAFETY: We just checked that `len` is stored on the heap.
             unsafe {
-                let len_ptr = ptr.sub(HeapBuffer::header_offset()).sub(size_of::<usize>());
+                let len_ptr = ptr.sub(HeapBuffer::growable_header_offset()).sub(size_of::<usize>());
                 ptr::write(len_ptr.as_ptr().cast(), len);
             }
         }
@@ -329,7 +350,29 @@ impl HeapBuffer {
         }
     }
 
-    fn allocate_ptr(capacity: Capacity) -> Result<NonNull<u8>, ReserveError> {
+    fn allocate_exact_ptr(len: usize) -> Result<NonNull<u8>, ReserveError> {
+        let layout = HeapBuffer::layout_from_len(len)?;
+
+        // SAFETY: layout is non-zero.
+        let mut allocation = unsafe { alloc(layout) };
+        if allocation.is_null() {
+            return Err(ReserveError);
+        }
+
+        if is_len_heap_layout(Capacity::new(len)?) {
+            // SAFETY: The layout reserved a leading word for the length.
+            unsafe { allocation = allocation.add(size_of::<usize>()) };
+        }
+
+        // SAFETY: The allocation includes an `ExactHeader` followed by `len` data bytes.
+        unsafe {
+            ptr::write(allocation.cast(), ExactHeader { count: AtomicUsize::new(1) });
+            let ptr = allocation.add(HeapBuffer::exact_header_offset());
+            Ok(NonNull::new_unchecked(ptr))
+        }
+    }
+
+    fn allocate_growable_ptr(capacity: Capacity) -> Result<NonNull<u8>, ReserveError> {
         let layout = HeapBuffer::layout_from_capacity(capacity)?;
 
         // SAFETY: layout is non-zero.
@@ -350,14 +393,23 @@ impl HeapBuffer {
         // - allocation is non-null.
         // - allocation size is larger than or equal to the size of Header.
         unsafe {
-            ptr::write(allocation.cast(), Header { count: AtomicUsize::new(1), capacity });
-            let ptr = allocation.add(HeapBuffer::header_offset());
+            ptr::write(allocation.cast(), Header { capacity, count: AtomicUsize::new(1) });
+            let ptr = allocation.add(HeapBuffer::growable_header_offset());
             Ok(NonNull::new_unchecked(ptr))
         }
     }
 
+    fn layout_from_len(len: usize) -> Result<Layout, ReserveError> {
+        let capacity = Capacity::new(len)?;
+        HeapBuffer::layout(HeapBuffer::exact_header_offset(), capacity)
+    }
+
     fn layout_from_capacity(capacity: Capacity) -> Result<Layout, ReserveError> {
-        let alloc_size = size_of::<Header>()
+        HeapBuffer::layout(HeapBuffer::growable_header_offset(), capacity)
+    }
+
+    fn layout(header_size: usize, capacity: Capacity) -> Result<Layout, ReserveError> {
+        let alloc_size = header_size
             .checked_add(capacity.as_usize())
             .and_then(|size| {
                 if is_len_heap_layout(capacity) {
@@ -376,29 +428,56 @@ impl HeapBuffer {
 
     unsafe fn allocation(&self) -> *mut u8 {
         unsafe {
-            if is_len_heap_layout(self.header().capacity) {
+            if self.has_heap_len_layout() {
                 cold_path();
-                self.ptr.as_ptr().cast::<u8>().sub(Self::header_offset()).sub(size_of::<usize>())
+                self.ptr.as_ptr().cast::<u8>().sub(self.header_offset()).sub(size_of::<usize>())
             } else {
-                self.ptr.as_ptr().cast::<u8>().sub(Self::header_offset())
+                self.ptr.as_ptr().cast::<u8>().sub(self.header_offset())
             }
         }
     }
 
     fn header(&self) -> &Header {
-        unsafe { &*self.ptr.as_ptr().sub(HeapBuffer::header_offset()).cast() }
+        debug_assert!(!self.is_exact());
+        unsafe { &*self.ptr.as_ptr().sub(HeapBuffer::growable_header_offset()).cast() }
+    }
+
+    fn exact_header(&self) -> &ExactHeader {
+        debug_assert!(self.is_exact());
+        unsafe { &*self.ptr.as_ptr().sub(HeapBuffer::exact_header_offset()).cast() }
+    }
+
+    fn has_heap_len_layout(&self) -> bool {
+        if self.is_exact() {
+            self.len.is_heap()
+        } else {
+            is_len_heap_layout(self.header().capacity)
+        }
     }
 
     const fn align() -> usize {
         const {
             assert!(align_of::<Header>() == align_of::<usize>());
+            assert!(align_of::<ExactHeader>() == align_of::<usize>());
             assert!(align_of::<NonNull<u8>>() == align_of::<usize>());
         }
         align_of::<usize>()
     }
 
-    const fn header_offset() -> usize {
+    const fn exact_header_offset() -> usize {
+        max(size_of::<ExactHeader>(), HeapBuffer::align())
+    }
+
+    const fn growable_header_offset() -> usize {
         max(size_of::<Header>(), HeapBuffer::align())
+    }
+
+    const fn header_offset(&self) -> usize {
+        if self.is_exact() {
+            HeapBuffer::exact_header_offset()
+        } else {
+            HeapBuffer::growable_header_offset()
+        }
     }
 }
 
@@ -422,7 +501,7 @@ mod internal {
     /// | (size_of::<usize>() - 1) bytes | 1 byte |
     /// +--------------------------------+--------+
     ///
-    /// And the tag is [`LastByte::Heap`].
+    /// The tag distinguishes exact buffers from growable buffers.
     ///
     /// In this representation, the max value is limited to:
     ///
@@ -446,27 +525,56 @@ mod internal {
     };
 
     impl TextLen {
-        const TAG: usize = {
+        const EXACT_TAG: usize = {
+            let mut bytes = [0; USIZE_SIZE];
+            bytes[USIZE_SIZE - 1] = LastByte::ExactHeapMarker as u8;
+            usize::from_ne_bytes(bytes)
+        };
+
+        const GROWABLE_TAG: usize = {
             let mut bytes = [0; USIZE_SIZE];
             bytes[USIZE_SIZE - 1] = LastByte::HeapMarker as u8;
             usize::from_ne_bytes(bytes)
         };
 
         #[cfg(target_pointer_width = "32")]
-        const ON_THE_HEAP: usize = {
+        const EXACT_ON_THE_HEAP: usize = {
+            let mut bytes = [255; USIZE_SIZE];
+            bytes[USIZE_SIZE - 1] = LastByte::ExactHeapMarker as u8;
+            usize::from_ne_bytes(bytes)
+        };
+
+        #[cfg(target_pointer_width = "32")]
+        const GROWABLE_ON_THE_HEAP: usize = {
             let mut bytes = [255; USIZE_SIZE];
             bytes[USIZE_SIZE - 1] = LastByte::HeapMarker as u8;
             usize::from_ne_bytes(bytes)
         };
 
-        pub(super) const fn new(size: usize) -> Result<Self, ReserveError> {
+        pub(super) const fn new_exact(size: usize) -> Result<Self, ReserveError> {
+            Self::new(size, Self::EXACT_TAG)
+        }
+
+        pub(super) const fn new_growable(size: usize) -> Result<Self, ReserveError> {
+            Self::new(size, Self::GROWABLE_TAG)
+        }
+
+        const fn new(size: usize, tag: usize) -> Result<Self, ReserveError> {
             if size > MAX_LEN {
                 #[cfg(target_pointer_width = "64")]
                 return Err(ReserveError);
                 #[cfg(target_pointer_width = "32")]
-                return Ok(TextLen(Self::ON_THE_HEAP));
+                return Ok(TextLen(if tag == Self::EXACT_TAG {
+                    Self::EXACT_ON_THE_HEAP
+                } else {
+                    Self::GROWABLE_ON_THE_HEAP
+                }));
             }
-            Ok(TextLen(size.to_le() | Self::TAG))
+            Ok(TextLen(size.to_le() | tag))
+        }
+
+        pub(super) const fn is_exact(&self) -> bool {
+            self.tag() == Self::EXACT_TAG
         }
 
         #[inline(always)]
@@ -474,13 +582,24 @@ mod internal {
             #[cfg(target_pointer_width = "64")]
             return false;
             #[cfg(target_pointer_width = "32")]
-            return self.0 == Self::ON_THE_HEAP;
+            return self.0
+                == if self.is_exact() {
+                    Self::EXACT_ON_THE_HEAP
+                } else {
+                    Self::GROWABLE_ON_THE_HEAP
+                };
         }
 
         pub(super) const fn as_usize(self) -> usize {
-            let size = self.0 ^ Self::TAG;
+            let size = self.0 ^ self.tag();
             let bytes = size.to_ne_bytes();
             usize::from_le_bytes(bytes)
+        }
+
+        const fn tag(&self) -> usize {
+            let mut bytes = [0; USIZE_SIZE];
+            bytes[USIZE_SIZE - 1] = self.0.to_ne_bytes()[USIZE_SIZE - 1];
+            usize::from_ne_bytes(bytes)
         }
     }
 
@@ -531,10 +650,55 @@ mod internal {
 
         #[test]
         fn heap_stored_length_preserves_repr_tag() {
-            let len = TextLen::new(MAX_LEN + 1).unwrap();
+            let exact = TextLen::new_exact(MAX_LEN + 1).unwrap();
+            let growable = TextLen::new_growable(MAX_LEN + 1).unwrap();
 
-            assert!(len.is_heap());
-            assert_eq!(len.0.to_ne_bytes()[USIZE_SIZE - 1], LastByte::HeapMarker as u8);
+            assert!(exact.is_heap());
+            assert!(exact.is_exact());
+            assert_eq!(exact.0.to_ne_bytes()[USIZE_SIZE - 1], LastByte::ExactHeapMarker as u8);
+            assert!(growable.is_heap());
+            assert!(!growable.is_exact());
+            assert_eq!(growable.0.to_ne_bytes()[USIZE_SIZE - 1], LastByte::HeapMarker as u8);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_layout_omits_capacity() {
+        assert_eq!(HeapBuffer::exact_header_offset(), size_of::<AtomicUsize>());
+        assert_eq!(HeapBuffer::growable_header_offset(), 2 * size_of::<usize>());
+
+        let len = MAX_INLINE_SIZE + 1;
+        assert_eq!(
+            HeapBuffer::layout_from_len(len).unwrap().size(),
+            size_of::<AtomicUsize>() + len
+        );
+        assert_eq!(
+            HeapBuffer::layout_from_capacity(Capacity::new(len).unwrap()).unwrap().size(),
+            2 * size_of::<usize>() + len
+        );
+    }
+
+    #[test]
+    fn constructors_select_expected_layout() {
+        let text = "a string longer than the inline limit";
+        let mut exact = HeapBuffer::new_exact(text).unwrap();
+        let mut growable = HeapBuffer::new(text).unwrap();
+
+        assert!(exact.is_exact());
+        assert!(!growable.is_exact());
+        assert_eq!(exact.capacity(), text.len());
+        assert_eq!(growable.capacity(), text.len());
+
+        // SAFETY: These are the only live references to their respective allocations, and neither
+        // buffer is accessed afterward.
+        unsafe {
+            exact.release();
+            growable.release();
         }
     }
 }

--- a/src/repr/heap_buffer.rs
+++ b/src/repr/heap_buffer.rs
@@ -256,6 +256,113 @@ impl HeapBuffer {
         Ok(())
     }
 
+    /// Converts a unique growable allocation into an exact allocation.
+    ///
+    /// # Safety
+    ///
+    /// - The buffer must be unique. (`HeapBuffer::is_unique() == true`)
+    /// - The buffer must be growable. (`HeapBuffer::is_exact() == false`)
+    pub(super) unsafe fn realloc_into_exact(&mut self) -> Result<(), ReserveError> {
+        debug_assert!(!self.is_exact());
+        debug_assert!(self.is_unique());
+
+        let len = self.len();
+        let old_capacity = self.header().capacity;
+        let new_capacity = Capacity::new(len)?;
+        let new_len = TextLen::new_exact(len)?;
+        let old_layout = HeapBuffer::layout_from_capacity(old_capacity)?;
+        let new_layout = HeapBuffer::layout_from_len(len)?;
+        let old_len_prefix = if is_len_heap_layout(old_capacity) { size_of::<usize>() } else { 0 };
+        let new_len_prefix = if is_len_heap_layout(new_capacity) { size_of::<usize>() } else { 0 };
+
+        // SAFETY: `self` owns a live allocation described by `old_layout`.
+        let allocation = unsafe { self.allocation() };
+        // SAFETY: Both pointers lie within the current allocation. `ptr::copy` permits overlap,
+        // which is required because the exact data starts before the growable data.
+        let old_data =
+            unsafe { allocation.add(old_len_prefix + HeapBuffer::growable_header_offset()) };
+        let new_data =
+            unsafe { allocation.add(new_len_prefix + HeapBuffer::exact_header_offset()) };
+        unsafe { ptr::copy(old_data, new_data, len) };
+
+        // SAFETY:
+        // - `allocation` was allocated with `old_layout`.
+        // - `new_layout` has the same alignment and a nonzero size.
+        let new_allocation = unsafe { realloc(allocation, old_layout, new_layout.size()) };
+        if new_allocation.is_null() {
+            // `realloc` failure leaves the old allocation live. Restore the data and growable
+            // header before returning so `self` remains valid and can be dropped.
+            unsafe {
+                ptr::copy(new_data, old_data, len);
+                if old_len_prefix != 0 {
+                    ptr::write(allocation.cast(), len);
+                }
+                let header = allocation.add(old_len_prefix).cast::<Header>();
+                ptr::write(header, Header { capacity: old_capacity, count: AtomicUsize::new(1) });
+            }
+            return Err(ReserveError);
+        }
+
+        // SAFETY: `new_allocation` is a live allocation described by `new_layout`. The initialized
+        // string bytes were moved into the retained exact-layout prefix before shrinking.
+        unsafe {
+            if new_len_prefix != 0 {
+                ptr::write(new_allocation.cast(), len);
+            }
+            let header = new_allocation.add(new_len_prefix).cast::<ExactHeader>();
+            ptr::write(header, ExactHeader { count: AtomicUsize::new(1) });
+            let data = new_allocation.add(new_len_prefix + HeapBuffer::exact_header_offset());
+            self.ptr = NonNull::new_unchecked(data);
+        }
+        self.len = new_len;
+        Ok(())
+    }
+
+    /// Converts a unique exact allocation into a growable allocation with capacity equal to its
+    /// length.
+    ///
+    /// # Safety
+    ///
+    /// - The buffer must be unique. (`HeapBuffer::is_unique() == true`)
+    /// - The buffer must be exact. (`HeapBuffer::is_exact() == true`)
+    pub(super) unsafe fn realloc_into_growable(&mut self) -> Result<(), ReserveError> {
+        debug_assert!(self.is_exact());
+        debug_assert!(self.is_unique());
+
+        let len = self.len();
+        let capacity = Capacity::new(len)?;
+        let new_len = TextLen::new_growable(len)?;
+        let old_layout = HeapBuffer::layout_from_len(len)?;
+        let new_layout = HeapBuffer::layout_from_capacity(capacity)?;
+        let len_prefix = if is_len_heap_layout(capacity) { size_of::<usize>() } else { 0 };
+
+        // SAFETY: `self` owns a live allocation described by `old_layout`.
+        let allocation = unsafe { self.allocation() };
+        // SAFETY:
+        // - `allocation` was allocated with `old_layout`.
+        // - `new_layout` has the same alignment and a nonzero size.
+        let new_allocation = unsafe { realloc(allocation, old_layout, new_layout.size()) };
+        if new_allocation.is_null() {
+            return Err(ReserveError);
+        }
+
+        // SAFETY: The expanded allocation contains the old exact-layout bytes. Move the string to
+        // its growable offset before writing the larger header. `ptr::copy` permits overlap.
+        unsafe {
+            let old_data = new_allocation.add(len_prefix + HeapBuffer::exact_header_offset());
+            let new_data = new_allocation.add(len_prefix + HeapBuffer::growable_header_offset());
+            ptr::copy(old_data, new_data, len);
+            if len_prefix != 0 {
+                ptr::write(new_allocation.cast(), len);
+            }
+            let header = new_allocation.add(len_prefix).cast::<Header>();
+            ptr::write(header, Header { capacity, count: AtomicUsize::new(1) });
+            self.ptr = NonNull::new_unchecked(new_data);
+        }
+        self.len = new_len;
+        Ok(())
+    }
+
     /// Decrements the reference count. If this was the last reference, deallocates the buffer.
     ///
     /// # Safety
@@ -702,5 +809,48 @@ mod tests {
             exact.release();
             growable.release();
         }
+    }
+
+    #[test]
+    fn realloc_between_exact_and_growable_layouts() {
+        let text = "short multibyte text: é日";
+        let mut buffer = HeapBuffer::with_exact_capacity(text, 128).unwrap();
+
+        assert!(!buffer.is_exact());
+        assert_eq!(buffer.capacity(), 128);
+
+        // SAFETY: `buffer` is the only reference to this growable allocation.
+        unsafe { buffer.realloc_into_exact().unwrap() };
+
+        assert!(buffer.is_exact());
+        assert_eq!(buffer.as_str(), text);
+        assert_eq!(buffer.capacity(), text.len());
+
+        // SAFETY: `buffer` is the only reference to this exact allocation.
+        unsafe { buffer.realloc_into_growable().unwrap() };
+
+        assert!(!buffer.is_exact());
+        assert_eq!(buffer.as_str(), text);
+        assert_eq!(buffer.capacity(), text.len());
+
+        // SAFETY: `buffer` is the only live reference and is not accessed afterward.
+        unsafe { buffer.release() };
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn realloc_into_exact_removes_heap_length_prefix() {
+        let mut buffer = HeapBuffer::with_exact_capacity("short", 1 << 24).unwrap();
+        assert!(buffer.has_heap_len_layout());
+
+        // SAFETY: `buffer` is the only reference to this growable allocation.
+        unsafe { buffer.realloc_into_exact().unwrap() };
+
+        assert!(buffer.is_exact());
+        assert!(!buffer.has_heap_len_layout());
+        assert_eq!(buffer.as_str(), "short");
+
+        // SAFETY: `buffer` is the only live reference and is not accessed afterward.
+        unsafe { buffer.release() };
     }
 }

--- a/src/repr/last_byte.rs
+++ b/src/repr/last_byte.rs
@@ -226,8 +226,9 @@ pub enum LastByte {
     Length14 = 0xCE,
     Length15 = 0xCF,
 
-    HeapMarker = 0xD0,
-    StaticMarker = 0xD1,
+    ExactHeapMarker = 0xD0,
+    HeapMarker = 0xD1,
+    StaticMarker = 0xD2,
 }
 
 const _: () = {

--- a/tests/freeze_oom.rs
+++ b/tests/freeze_oom.rs
@@ -4,11 +4,12 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use lean_string::{LeanString, ReserveError};
+use lean_string::{LeanStr, LeanString, ReserveError};
 
 struct FailNextAllocation;
 
 static FAIL_NEXT_ALLOCATION: AtomicBool = AtomicBool::new(false);
+static FAIL_NEXT_REALLOCATION: AtomicBool = AtomicBool::new(false);
 
 // SAFETY: Allocations are delegated to `System`, except for the single allocation explicitly
 // rejected by the test.
@@ -26,18 +27,63 @@ unsafe impl GlobalAlloc for FailNextAllocation {
         // SAFETY: `ptr` was allocated by `System` with this layout.
         unsafe { System.dealloc(ptr, layout) }
     }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if FAIL_NEXT_REALLOCATION.swap(false, Ordering::SeqCst) {
+            ptr::null_mut()
+        } else {
+            // SAFETY: The caller provides a pointer allocated with `layout`, and `new_size` is the
+            // requested replacement allocation size.
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
 }
 
 #[global_allocator]
 static ALLOCATOR: FailNextAllocation = FailNextAllocation;
 
 #[test]
-fn try_freeze_reports_allocation_failure() {
+fn fallible_heap_conversions_report_allocation_failure() {
+    const TEXT: &str = "a string longer than the inline limit";
+
+    // A unique growable allocation is converted to exact storage with `realloc`.
     let mut string = LeanString::with_capacity(128);
-    string.push_str("a string longer than the inline limit");
+    string.push_str(TEXT);
+
+    FAIL_NEXT_REALLOCATION.store(true, Ordering::SeqCst);
+    let result = string.try_freeze();
+    FAIL_NEXT_REALLOCATION.store(false, Ordering::SeqCst);
+
+    assert_eq!(result, Err(ReserveError));
+
+    // A shared growable allocation is copied into a new exact allocation.
+    let string = LeanString::from(TEXT);
+    let growable = string.clone();
 
     FAIL_NEXT_ALLOCATION.store(true, Ordering::SeqCst);
     let result = string.try_freeze();
+    FAIL_NEXT_ALLOCATION.store(false, Ordering::SeqCst);
 
     assert_eq!(result, Err(ReserveError));
+    assert_eq!(growable, TEXT);
+
+    // A unique exact allocation is converted to growable storage with `realloc`.
+    let frozen = LeanStr::from(TEXT);
+
+    FAIL_NEXT_REALLOCATION.store(true, Ordering::SeqCst);
+    let result = frozen.try_into_lean_string();
+    FAIL_NEXT_REALLOCATION.store(false, Ordering::SeqCst);
+
+    assert_eq!(result, Err(ReserveError));
+
+    // A shared exact allocation is copied into a new growable allocation.
+    let frozen = LeanStr::from(TEXT);
+    let exact = frozen.clone();
+
+    FAIL_NEXT_ALLOCATION.store(true, Ordering::SeqCst);
+    let result = frozen.try_into_lean_string();
+    FAIL_NEXT_ALLOCATION.store(false, Ordering::SeqCst);
+
+    assert_eq!(result, Err(ReserveError));
+    assert_eq!(exact, TEXT);
 }

--- a/tests/freeze_oom.rs
+++ b/tests/freeze_oom.rs
@@ -1,0 +1,43 @@
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    ptr,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use lean_string::{LeanString, ReserveError};
+
+struct FailNextAllocation;
+
+static FAIL_NEXT_ALLOCATION: AtomicBool = AtomicBool::new(false);
+
+// SAFETY: Allocations are delegated to `System`, except for the single allocation explicitly
+// rejected by the test.
+unsafe impl GlobalAlloc for FailNextAllocation {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if FAIL_NEXT_ALLOCATION.swap(false, Ordering::SeqCst) {
+            ptr::null_mut()
+        } else {
+            // SAFETY: The caller provides a valid layout.
+            unsafe { System.alloc(layout) }
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` was allocated by `System` with this layout.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: FailNextAllocation = FailNextAllocation;
+
+#[test]
+fn try_freeze_reports_allocation_failure() {
+    let mut string = LeanString::with_capacity(128);
+    string.push_str("a string longer than the inline limit");
+
+    FAIL_NEXT_ALLOCATION.store(true, Ordering::SeqCst);
+    let result = string.try_freeze();
+
+    assert_eq!(result, Err(ReserveError));
+}

--- a/tests/lean_str.rs
+++ b/tests/lean_str.rs
@@ -43,6 +43,33 @@ fn freeze_and_thaw() {
 }
 
 #[test]
+fn clear_unique_thawed_string_releases_exact_storage() {
+    let mut thawed =
+        LeanStr::from("a frozen string longer than the inline limit").into_lean_string();
+
+    thawed.clear();
+
+    assert!(thawed.is_empty());
+    assert_eq!(thawed.capacity(), INLINE_LIMIT);
+    assert!(!thawed.is_heap_allocated());
+}
+
+#[test]
+fn clear_shared_thawed_string_preserves_frozen_clone() {
+    let frozen = LeanStr::from("a frozen string longer than the inline limit");
+    let shared = frozen.clone();
+    let mut thawed = frozen.into_lean_string();
+
+    thawed.clear();
+
+    assert!(thawed.is_empty());
+    assert_eq!(thawed.capacity(), INLINE_LIMIT);
+    assert!(!thawed.is_heap_allocated());
+    assert_eq!(shared, "a frozen string longer than the inline limit");
+    assert!(shared.is_heap_allocated());
+}
+
+#[test]
 fn collect_freezes_builder() {
     let frozen: LeanStr = "a string longer than the inline limit".chars().collect();
 

--- a/tests/lean_str.rs
+++ b/tests/lean_str.rs
@@ -1,0 +1,51 @@
+use lean_string::{LeanStr, LeanString};
+
+const INLINE_LIMIT: usize = size_of::<LeanStr>();
+
+#[test]
+fn size() {
+    assert_eq!(size_of::<LeanStr>(), 2 * size_of::<usize>());
+    assert_eq!(size_of::<Option<LeanStr>>(), size_of::<LeanStr>());
+}
+
+#[test]
+fn storage_kinds() {
+    let inline = LeanStr::from("x".repeat(INLINE_LIMIT));
+    let heap = LeanStr::from("x".repeat(INLINE_LIMIT + 1));
+    const STATIC: LeanStr =
+        LeanStr::from_static_str("a static string longer than the inline limit");
+
+    assert!(!inline.is_heap_allocated());
+    assert!(heap.is_heap_allocated());
+    assert!(!STATIC.is_heap_allocated());
+}
+
+#[test]
+fn clone_shares_heap_storage() {
+    let one = LeanStr::from("a string longer than the inline limit");
+    let two = one.clone();
+
+    assert!(core::ptr::eq(one.as_ptr(), two.as_ptr()));
+}
+
+#[test]
+fn freeze_and_thaw() {
+    let mut string = LeanString::with_capacity(128);
+    string.push_str("a string longer than the inline limit");
+
+    let frozen = string.freeze();
+    let shared = frozen.clone();
+    let mut thawed = frozen.into_lean_string();
+    thawed.push_str(" with more text");
+
+    assert_eq!(shared, "a string longer than the inline limit");
+    assert_eq!(thawed, "a string longer than the inline limit with more text");
+}
+
+#[test]
+fn collect_freezes_builder() {
+    let frozen: LeanStr = "a string longer than the inline limit".chars().collect();
+
+    assert_eq!(frozen, "a string longer than the inline limit");
+    assert!(frozen.is_heap_allocated());
+}

--- a/tests/lean_str.rs
+++ b/tests/lean_str.rs
@@ -43,6 +43,19 @@ fn freeze_and_thaw() {
 }
 
 #[test]
+fn try_freeze_compacts_growable_storage() {
+    let text = "a string longer than the inline limit";
+    let mut string = LeanString::with_capacity(128);
+    string.push_str(text);
+
+    let frozen = string.try_freeze().unwrap();
+    let thawed = frozen.into_lean_string();
+
+    assert_eq!(thawed, text);
+    assert_eq!(thawed.capacity(), thawed.len());
+}
+
+#[test]
 fn clear_unique_thawed_string_releases_exact_storage() {
     let mut thawed =
         LeanStr::from("a frozen string longer than the inline limit").into_lean_string();

--- a/tests/lean_str.rs
+++ b/tests/lean_str.rs
@@ -29,21 +29,26 @@ fn clone_shares_heap_storage() {
 }
 
 #[test]
-fn freeze_and_thaw() {
+fn shared_heap_conversions_copy_storage() {
     let mut string = LeanString::with_capacity(128);
     string.push_str("a string longer than the inline limit");
+    let growable = string.clone();
 
     let frozen = string.freeze();
     let shared = frozen.clone();
     let mut thawed = frozen.into_lean_string();
+    let thawed_ptr = thawed.as_ptr();
     thawed.push_str(" with more text");
 
+    assert!(!core::ptr::eq(growable.as_ptr(), shared.as_ptr()));
+    assert!(!core::ptr::eq(shared.as_ptr(), thawed_ptr));
+    assert_eq!(growable, "a string longer than the inline limit");
     assert_eq!(shared, "a string longer than the inline limit");
     assert_eq!(thawed, "a string longer than the inline limit with more text");
 }
 
 #[test]
-fn try_freeze_compacts_growable_storage() {
+fn unique_heap_conversions_preserve_contents() {
     let text = "a string longer than the inline limit";
     let mut string = LeanString::with_capacity(128);
     string.push_str(text);
@@ -56,15 +61,50 @@ fn try_freeze_compacts_growable_storage() {
 }
 
 #[test]
-fn clear_unique_thawed_string_releases_exact_storage() {
+fn inline_and_static_conversions_preserve_storage_kind() {
+    let inline = LeanString::from("short").freeze();
+    assert!(!inline.is_heap_allocated());
+    assert!(!inline.into_lean_string().is_heap_allocated());
+
+    const TEXT: &str = "a static string longer than the inline limit";
+    let string = LeanString::from_static_str(TEXT);
+    let ptr = string.as_ptr();
+    let frozen = string.freeze();
+
+    assert!(!frozen.is_heap_allocated());
+    assert!(core::ptr::eq(ptr, frozen.as_ptr()));
+
+    let thawed = frozen.into_lean_string();
+    assert!(!thawed.is_heap_allocated());
+    assert!(core::ptr::eq(ptr, thawed.as_ptr()));
+}
+
+#[test]
+fn heap_conversions_preserve_storage_for_short_contents() {
+    let string = LeanString::with_capacity(INLINE_LIMIT + 1);
+    assert!(string.is_heap_allocated());
+
+    let frozen = string.freeze();
+    assert!(frozen.is_heap_allocated());
+    assert!(frozen.is_empty());
+
+    let thawed = frozen.into_lean_string();
+    assert!(thawed.is_heap_allocated());
+    assert!(thawed.is_empty());
+    assert_eq!(thawed.capacity(), 0);
+}
+
+#[test]
+fn clear_unique_thawed_string_retains_growable_storage() {
     let mut thawed =
         LeanStr::from("a frozen string longer than the inline limit").into_lean_string();
+    let capacity = thawed.capacity();
 
     thawed.clear();
 
     assert!(thawed.is_empty());
-    assert_eq!(thawed.capacity(), INLINE_LIMIT);
-    assert!(!thawed.is_heap_allocated());
+    assert_eq!(thawed.capacity(), capacity);
+    assert!(thawed.is_heap_allocated());
 }
 
 #[test]
@@ -72,14 +112,30 @@ fn clear_shared_thawed_string_preserves_frozen_clone() {
     let frozen = LeanStr::from("a frozen string longer than the inline limit");
     let shared = frozen.clone();
     let mut thawed = frozen.into_lean_string();
+    let capacity = thawed.capacity();
 
     thawed.clear();
 
     assert!(thawed.is_empty());
-    assert_eq!(thawed.capacity(), INLINE_LIMIT);
-    assert!(!thawed.is_heap_allocated());
+    assert_eq!(thawed.capacity(), capacity);
+    assert!(thawed.is_heap_allocated());
     assert_eq!(shared, "a frozen string longer than the inline limit");
     assert!(shared.is_heap_allocated());
+}
+
+#[test]
+fn shrink_to_fit_keeps_growable_heap_storage() {
+    let text = "a string longer than the inline limit";
+    let mut string = LeanString::with_capacity(128);
+    string.push_str(text);
+
+    string.shrink_to_fit();
+    assert_eq!(string.capacity(), text.len());
+
+    string.clear();
+    assert!(string.is_empty());
+    assert_eq!(string.capacity(), text.len());
+    assert!(string.is_heap_allocated());
 }
 
 #[test]

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -43,6 +43,39 @@ loom_test! {
 }
 
 loom_test! {
+    fn concurrent_drop_and_thaw() {
+        let frozen = LeanStr::from("a frozen string longer than the inline limit");
+        let shared = frozen.clone();
+
+        let th = thread::spawn(move || {
+            drop(shared);
+        });
+
+        let thawed = frozen.into_lean_string();
+        assert_eq!(thawed, "a frozen string longer than the inline limit");
+
+        th.join().unwrap();
+    }
+}
+
+loom_test! {
+    fn concurrent_drop_and_freeze() {
+        let mut string = LeanString::with_capacity(128);
+        string.push_str("a string longer than the inline limit");
+        let shared = string.clone();
+
+        let th = thread::spawn(move || {
+            drop(shared);
+        });
+
+        let frozen = string.freeze();
+        assert_eq!(frozen, "a string longer than the inline limit");
+
+        th.join().unwrap();
+    }
+}
+
+loom_test! {
     fn concurrent_push() {
         let mut one = LeanString::from("12345678901234567890");
         let two = one.clone();

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,7 +1,7 @@
 // RUSTFLAGS="--cfg loom" cargo test --test loom --release --features loom -- --test-threads=1
 #![cfg(loom)]
 
-use lean_string::LeanString;
+use lean_string::{LeanStr, LeanString};
 use loom::thread;
 
 #[global_allocator]
@@ -22,6 +22,24 @@ macro_rules! loom_test {
             });
         }
     };
+}
+
+loom_test! {
+    fn concurrent_frozen_clone_and_thaw() {
+        let frozen = LeanStr::from("a frozen string longer than the inline limit");
+        let shared = frozen.clone();
+
+        let th = thread::spawn(move || {
+            let clone = shared.clone();
+            assert_eq!(clone, "a frozen string longer than the inline limit");
+        });
+
+        let mut thawed = frozen.into_lean_string();
+        thawed.push('!');
+        assert_eq!(thawed, "a frozen string longer than the inline limit!");
+
+        th.join().unwrap();
+    }
 }
 
 loom_test! {

--- a/tests/race_condition.rs
+++ b/tests/race_condition.rs
@@ -4,8 +4,24 @@
 // because they are UB (not logic errors). Miri with preemption is the right tool: it explores
 // thread interleavings and flags reads/writes to deallocated memory.
 
-use lean_string::LeanString;
+use lean_string::{LeanStr, LeanString};
 use std::thread;
+
+#[test]
+fn drop_while_mutating_thawed_string() {
+    let frozen = LeanStr::from("a frozen string longer than the inline limit");
+    let shared = frozen.clone();
+    let mut thawed = frozen.into_lean_string();
+
+    let th = thread::spawn(move || {
+        drop(shared);
+    });
+
+    thawed.push('!');
+    assert_eq!(thawed, "a frozen string longer than the inline limit!");
+
+    th.join().unwrap();
+}
 
 #[test]
 fn drop_while_push() {

--- a/tests/race_condition.rs
+++ b/tests/race_condition.rs
@@ -11,14 +11,30 @@ use std::thread;
 fn drop_while_mutating_thawed_string() {
     let frozen = LeanStr::from("a frozen string longer than the inline limit");
     let shared = frozen.clone();
-    let mut thawed = frozen.into_lean_string();
 
     let th = thread::spawn(move || {
         drop(shared);
     });
 
+    let mut thawed = frozen.into_lean_string();
     thawed.push('!');
     assert_eq!(thawed, "a frozen string longer than the inline limit!");
+
+    th.join().unwrap();
+}
+
+#[test]
+fn drop_while_freezing_string() {
+    let mut string = LeanString::with_capacity(128);
+    string.push_str("a string longer than the inline limit");
+    let shared = string.clone();
+
+    let th = thread::spawn(move || {
+        drop(shared);
+    });
+
+    let frozen = string.freeze();
+    assert_eq!(frozen, "a string longer than the inline limit");
 
     th.join().unwrap();
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,7 +1,7 @@
 // from: https://github.com/ParkMyCar/compact_str/blob/193d13eaa5a92b3c39c2f7289dc44c95f37c80d1/compact_str/src/features/serde.rs
 #![cfg(feature = "serde")]
 
-use lean_string::LeanString;
+use lean_string::{LeanStr, LeanString};
 use proptest::property_test;
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +48,15 @@ fn test_roundtrip() {
     // we should be able to deserailze from the opposite, serialized, source
     assert_eq!(std_de_compact, std);
     assert_eq!(compact_de_std, compact);
+}
+
+#[test]
+fn lean_str_roundtrip() {
+    let value = LeanStr::from("a frozen string longer than the inline limit");
+    let serialized = serde_json::to_string(&value).unwrap();
+    let deserialized: LeanStr = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized, value);
 }
 
 #[property_test]


### PR DESCRIPTION
This adds `LeanStr`, a compact immutable counterpart to `LeanString` that preserves the same two-word inline and static representations while using an exactly sized, reference-counted heap allocation. Exact allocations store only the reference count ahead of the UTF-8 bytes, so immutable values do not retain unused capacity and clones remain O(1).

The mutable and immutable types now have distinct heap invariants, mirroring `String` and `str`: every `LeanString` heap allocation stores a capacity and remains growable, while every `LeanStr` heap allocation is exact and capacity-less. `shrink_to` and `shrink_to_fit` therefore stay within the growable representation instead of introducing exact storage into `LeanString`.

`LeanString::freeze` and `try_freeze` convert growable storage to exact storage. The reverse direction is provided by `LeanStr::into_lean_string` and the new fallible `try_into_lean_string`. Inline and static values transfer directly, unique heap allocations are converted with `realloc`, and shared heap allocations are copied into the destination layout.

The unique conversion paths move initialized bytes across the differing header offsets and restore the original growable layout if a shrinking `realloc` fails. They also account for the optional heap-stored length prefix used by large 32-bit allocations.
